### PR TITLE
angular: existing list do not get initizlied

### DIFF
--- a/src/MediumEditorList.js
+++ b/src/MediumEditorList.js
@@ -14,7 +14,12 @@ var MediumEditorList = MediumEditor.Extension.extend({
         me.editor = this.base;
         me.listInstances = {};
         me.on(me.button, 'click', me.onClick.bind(me));
-        me.initExistsingLists();
+        // and it timeout to send at the end of the event stack. Need when used with angular.
+        (function (self) {
+            window.setTimeout(function () {
+                self.initExistsingLists();
+            }, 0);
+        })(me);
     },
     initExistsingLists: function () {
         var $lists = this.getExistsingLists(),

--- a/src/MediumEditorList.js
+++ b/src/MediumEditorList.js
@@ -14,7 +14,7 @@ var MediumEditorList = MediumEditor.Extension.extend({
         me.editor = this.base;
         me.listInstances = {};
         me.on(me.button, 'click', me.onClick.bind(me));
-        // and it timeout to send at the end of the event stack. Need when used with angular.
+        // call inside a timeout to send at the end of the event stack. Needed when used with angular.
         (function (self) {
             window.setTimeout(function () {
                 self.initExistsingLists();


### PR DESCRIPTION
Existing lists do not get initialized when MediumEditorList is used when angular because `getExistsingLists` returns null. Calling `initExistsingLists` inside a timeout will send it to the end of the JavaScript event loop allowing angular to finish binding all the values. When it executes, the lists items will be found as part of the `innerHTML`.
