### PR TITLE
getExistingLists returns only 1 list

### DIFF
--- a/src/MediumEditorList.js
+++ b/src/MediumEditorList.js
@@ -26,8 +26,8 @@ var MediumEditorList = MediumEditor.Extension.extend({
     },
     getExistingLists: function () {
         var $lists = this.editor.origElements[0]
-            ? this.editor.origElements[0].querySelector('ul.' + MEDIUM_EDITOR_CLASS)
-            : this.editor.origElements.querySelector('ul.' + MEDIUM_EDITOR_CLASS);
+            ? this.editor.origElements[0].querySelectorAll('ul.' + MEDIUM_EDITOR_CLASS)
+            : this.editor.origElements.querySelectorAll('ul.' + MEDIUM_EDITOR_CLASS);
         return isDefined($lists) ? $lists : [];
     },
     getButton: function () {


### PR DESCRIPTION
Updated getExistingLists to allow multiple lists to be used int he same Medium Editor. querySelector only returns the first item while querySelectorAll returns a node list of matching DOM objects.
